### PR TITLE
Fix CurlClient & StreamClient on default mode verify_peer and null ca_info

### DIFF
--- a/src/Psr18/CurlHandle.php
+++ b/src/Psr18/CurlHandle.php
@@ -103,7 +103,7 @@ class CurlHandle{
 			'2.0' => \CURL_HTTP_VERSION_2_0,
 		];
 
-		return [
+		$options = [
 			\CURLOPT_HEADER         => false,
 			\CURLOPT_RETURNTRANSFER => false,
 			\CURLOPT_FOLLOWLOCATION => false,
@@ -113,12 +113,15 @@ class CurlHandle{
 			\CURLOPT_PROTOCOLS      => \CURLPROTO_HTTP | \CURLPROTO_HTTPS,
 			\CURLOPT_SSL_VERIFYPEER => true,
 			\CURLOPT_SSL_VERIFYHOST => 2,
-			\CURLOPT_CAINFO         => $this->options->ca_info,
 			\CURLOPT_TIMEOUT        => 10,
 			\CURLOPT_CONNECTTIMEOUT => 30,
 			\CURLOPT_WRITEFUNCTION  => [$this, 'writefunction'],
 			\CURLOPT_HEADERFUNCTION => [$this, 'headerfunction'],
 		];
+		if ($this->options->ca_info) {
+            $options[\CURLOPT_CAINFO] = $this->options->ca_info;
+		}
+        return $options;
 	}
 
 	/**

--- a/src/Psr18/StreamClient.php
+++ b/src/Psr18/StreamClient.php
@@ -40,14 +40,14 @@ class StreamClient extends HTTPClientAbstract{
 				'max_redirects'    => 0,
 				'timeout'          => 5,
 			],
-			'ssl' => [
+			'ssl' => array_filter([
 				'cafile'              => $this->options->ca_info,
 				'verify_peer'         => $this->options->ssl_verifypeer,
 				'verify_depth'        => 3,
 				'peer_name'           => $uri->getHost(),
 				'ciphers'             => 'HIGH:!SSLv2:!SSLv3',
 				'disable_compression' => true,
-			],
+			]),
 		]);
 
 		$requestUri = (string)$uri->withFragment('');

--- a/tests/Psr18/CurlClientTest.php
+++ b/tests/Psr18/CurlClientTest.php
@@ -18,7 +18,6 @@ class CurlClientTest extends HTTPClientTestAbstract{
 
 	protected function setUp():void{
 		$options = new HTTPOptions([
-			'ca_info' => __DIR__.'/../cacert.pem',
 			'user_agent' => $this::USER_AGENT,
 		]);
 

--- a/tests/Psr18/StreamClientTest.php
+++ b/tests/Psr18/StreamClientTest.php
@@ -18,7 +18,6 @@ class StreamClientTest extends HTTPClientTestAbstract{
 
 	protected function setUp():void{
 		$options = new HTTPOptions([
-			'ca_info' => __DIR__.'/../cacert.pem',
 			'user_agent' => $this::USER_AGENT,
 		]);
 


### PR DESCRIPTION
The default mode for CurlClient and StreamClient is to verify peers, chich is good.
This is set in HTTPOptions.

The problem is that CurlClient and StreamClient set the value even if it is NULL and it make it fail instead of using default configured/system default values.

In this PR:
CurlClient (on CurlHandle) only set this option if can evaluate to true
StreamClient only set this option if can evaluate to true.

Feel free if you found a better way to test it or you don't like the way I did it.